### PR TITLE
feat: Add logs for kubelet non-ready nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM golang:alpine as builder
 WORKDIR /app
 ADD . ./
-RUN apk add git
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o aws-eks-asg-rolling-update-handler .
+RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -a -installsuffix cgo -o aws-eks-asg-rolling-update-handler .
 RUN apk --update add ca-certificates
 
 # Run the binary on an empty container

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:alpine as builder
 WORKDIR /app
 ADD . ./
+RUN apk add git
 RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o aws-eks-asg-rolling-update-handler .
 RUN apk --update add ca-certificates
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -239,6 +239,7 @@ func getReadyNodesAndNumberOfNonReadyNodesOrInstances(updatedInstances []*autosc
 		} else if kubeletCondition := conditions[len(conditions)-1]; kubeletCondition.Type == v1.NodeReady && kubeletCondition.Status == v1.ConditionTrue {
 			updatedReadyNodes = append(updatedReadyNodes, updatedNode)
 		} else {
+			log.Printf("[%s][%s] Skipping because kubelet on node is not reporting as ready", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId))
 			numberOfNonReadyNodesOrInstances++
 		}
 		// Cleaning up

--- a/main.go
+++ b/main.go
@@ -236,12 +236,17 @@ func getReadyNodesAndNumberOfNonReadyNodesOrInstances(updatedInstances []*autosc
 		if len(conditions) == 0 {
 			log.Printf("[%s][%s] For some magical reason, %s doesn't have any conditions, therefore it is impossible to determine whether the node is ready to accept new pods or not", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId), updatedNode.Name)
 			numberOfNonReadyNodesOrInstances++
-		} else if kubeletCondition := conditions[len(conditions)-1]; kubeletCondition.Type == v1.NodeReady && kubeletCondition.Status == v1.ConditionTrue {
-			updatedReadyNodes = append(updatedReadyNodes, updatedNode)
+		} else if kubeletCondition := conditions[len(conditions)-1]; kubeletCondition.Type == v1.NodeReady {
+			if kubeletCondition.Status == v1.ConditionTrue {
+				updatedReadyNodes = append(updatedReadyNodes, updatedNode)
+			} else {
+				log.Printf("[%s][%s] Skipping because kubelet condition %s is reporting as %s", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId), kubeletCondition.Type, kubeletCondition.Status)
+				numberOfNonReadyNodesOrInstances++
+			}
 		} else {
-			log.Printf("[%s][%s] Skipping because kubelet on node is not reporting as ready", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId))
+			log.Printf("[%s][%s] Skipping because expected kubelet on node to have condition %s with value %s, but it didn't", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId), v1.NodeReady, v1.ConditionTrue)
 			numberOfNonReadyNodesOrInstances++
-		}
+
 		// Cleaning up
 		// This is an edge case, but it may happen that an ASG's launch template is modified, creating a new
 		// template version, but then that new template version is deleted before the node has been terminated.

--- a/main.go
+++ b/main.go
@@ -246,6 +246,7 @@ func getReadyNodesAndNumberOfNonReadyNodesOrInstances(updatedInstances []*autosc
 		} else {
 			log.Printf("[%s][%s] Skipping because expected kubelet on node to have condition %s with value %s, but it didn't", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(updatedInstance.InstanceId), v1.NodeReady, v1.ConditionTrue)
 			numberOfNonReadyNodesOrInstances++
+		}
 
 		// Cleaning up
 		// This is an edge case, but it may happen that an ASG's launch template is modified, creating a new


### PR DESCRIPTION
This PR resolves two issues I've seen while using this application:

First, on some larger clusters we would see:

```
ASG has X non-ready updated nodes/instances, waiting until all nodes/instances are ready  
```

However, this would run in a loop with no indication of which instances were not ready even though according to kubectl, it seemed that all instances were ready.  Adding another log line to report which instances were not ready helps aid in troubleshooting nodes that are not ready for long periods of time.

---

Second, it adds git to the Dockerfile else, docker builds fail for me with the following error:

```
Step 4/9 : RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o aws-eks-asg-rolling-update-handler .
 ---> Running in 79e131118b89
go: missing Git command. See https://golang.org/s/gogetcmd
error obtaining VCS status: exec: "git": executable file not found in $PATH
        Use -buildvcs=false to disable VCS stamping.
The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o aws-eks-asg-rolling-update-handler .' returned a non-zero code: 1
```