### PR TITLE
feat: Improve rolling upgrade speed and add SLOW_MODE env var to retain old behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Therefore, this application will not run into any issues if it is restarted, res
 | EXECUTION_TIMEOUT            | Maximum execution duration before timing out in seconds                                                                                                                                                                | no       | `900`       |
 | POD_TERMINATION_GRACE_PERIOD | How long to wait for a pod to terminate in seconds; 0 means "delete immediately"; set to a negative value to use the pod's terminationGracePeriodSeconds.                                                              | no       | `-1`        |
 | METRICS_PORT                 | Port to bind metrics server to                                                                                                                                                                                         | no       | `8080`      |
-| METRICS                      | Expose metrics in Promtheus format at `:${METRICS_PORT}/metrics`                                                                                                                                                       | no       | `""`        | 
+| METRICS                      | Expose metrics in Prometheus format at `:${METRICS_PORT}/metrics`                                                                                                                                                      | no       | `""`        | 
+| SLOW_MODE                    | If enabled, every time a node is terminated during an execution, the current execution will stop rather than continuing to the next ASG                                                                                | no       | `false`     | 
+
+**NOTE:** Only one of `CLUSTER_NAME`, `AUTODISCOVERY_TAGS` or `AUTO_SCALING_GROUP_NAMES` must be set.
 
 
 ## Metrics

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ const (
 	EnvPodTerminationGracePeriod = "POD_TERMINATION_GRACE_PERIOD"
 	EnvMetrics                   = "METRICS"
 	EnvMetricsPort               = "METRICS_PORT"
+	EnvSlowMode                  = "SLOW_MODE"
 )
 
 type config struct {
@@ -41,6 +42,7 @@ type config struct {
 	PodTerminationGracePeriod int           // Defaults to -1
 	Metrics                   bool          // Defaults to false
 	MetricsPort               int           // Defaults to 8080
+	SlowMode                  bool          // Defaults to false
 }
 
 // Initialize is used to initialize the application's configuration
@@ -48,6 +50,7 @@ func Initialize() error {
 	cfg = &config{
 		Environment: strings.ToLower(os.Getenv(EnvEnvironment)),
 		Debug:       strings.ToLower(os.Getenv(EnvDebug)) == "true",
+		SlowMode:    strings.ToLower(os.Getenv(EnvSlowMode)) == "true",
 	}
 	if clusterName := os.Getenv(EnvClusterName); len(clusterName) > 0 {
 		cfg.AutodiscoveryTags = fmt.Sprintf("k8s.io/cluster-autoscaler/%s=owned,k8s.io/cluster-autoscaler/enabled=true", clusterName)
@@ -103,8 +106,8 @@ func Initialize() error {
 		log.Printf("Environment variable '%s' not specified, defaulting to 20 seconds", EnvExecutionInterval)
 		cfg.ExecutionInterval = time.Second * 20
 	}
-	if executionTImeout := os.Getenv(EnvExecutionTimeout); len(executionTImeout) > 0 {
-		if timeout, err := strconv.Atoi(executionTImeout); err != nil {
+	if executionTimeout := os.Getenv(EnvExecutionTimeout); len(executionTimeout) > 0 {
+		if timeout, err := strconv.Atoi(executionTimeout); err != nil {
 			return fmt.Errorf("environment variable '%s' must be an integer", EnvExecutionTimeout)
 		} else {
 			cfg.ExecutionTimeout = time.Second * time.Duration(timeout)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ func TestInitialize(t *testing.T) {
 	_ = os.Setenv(EnvAutoScalingGroupNames, "asg-a,asg-b,asg-c")
 	_ = os.Setenv(EnvIgnoreDaemonSets, "false")
 	_ = os.Setenv(EnvDeleteLocalData, "false")
+	_ = os.Setenv(EnvSlowMode, "true")
 	defer os.Clearenv()
 	_ = Initialize()
 	config := Get()
@@ -17,10 +18,13 @@ func TestInitialize(t *testing.T) {
 		t.Error()
 	}
 	if config.IgnoreDaemonSets {
-		t.Error()
+		t.Error("IgnoreDaemonSets should be false")
 	}
 	if config.DeleteEmptyDirData {
-		t.Error()
+		t.Error("DeleteEmptyDirData should be false")
+	}
+	if !config.SlowMode {
+		t.Error("SlowMode should be true")
 	}
 }
 
@@ -37,6 +41,9 @@ func TestInitialize_withDefaultNonRequiredValues(t *testing.T) {
 	}
 	if !config.DeleteEmptyDirData {
 		t.Error("should've defaulted to deleting local data")
+	}
+	if config.SlowMode {
+		t.Error("SlowMode should be false")
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Before, when a node was drained/terminated, we used to stop the current execution instead of moving to the next ASG.

This offers a very safe rolling upgrade, but also extremely slow rolling upgrade process for large clusters.

Once this PR is merged, after a node is drained/terminated, we now move on to the next ASG unless `SLOW_MODE` is set to `true`.

The reason why I decided this change was necessary is that if there's one ASG per AZ, it's possible that you'll end up upgrading one AZ at a time (as the first ASG will always be the same) which may be a good or a bad thing.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
