### PR TITLE
fix: Prevent never-ending upgrade due to the cordoned-at annotation introduced in #42

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -135,21 +135,21 @@ func Initialize() error {
 
 // Set sets the application's configuration and is intended to be used for testing purposes.
 // See Initialize() for production
-func Set(autoScalingGroupNames []string, ignoreDaemonSets, deleteEmptyDirData bool) {
+func Set(autoScalingGroupNames []string, ignoreDaemonSets, deleteEmptyDirData, eagerCordoning bool) {
 	cfg = &config{
 		AutoScalingGroupNames: autoScalingGroupNames,
 		IgnoreDaemonSets:      ignoreDaemonSets,
 		DeleteEmptyDirData:    deleteEmptyDirData,
+		EagerCordoning:        eagerCordoning,
+		ExecutionInterval:     time.Second * 20,
+		ExecutionTimeout:      time.Second * 900,
 	}
 }
 
 func Get() *config {
 	if cfg == nil {
 		log.Println("Config wasn't initialized prior to being called. Assuming this is a test.")
-		cfg = &config{
-			ExecutionInterval: time.Second * 20,
-			ExecutionTimeout:  time.Second * 900,
-		}
+		Set(nil, true, true, false)
 	}
 	return cfg
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ func TestInitialize_withMissingRequiredValues(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	Set([]string{"asg-a", "asg-b", "asg-c"}, true, true)
+	Set([]string{"asg-a", "asg-b", "asg-c"}, true, true, false)
 	config := Get()
 	if len(config.AutoScalingGroupNames) != 3 {
 		t.Error()

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	AnnotationRollingUpdateStartedTimestamp    = "aws-eks-asg-rolling-update-handler.twin.sh/started-at"
-	AnnotationRollingUpdateCordonedTimestamp   = "aws-eks-asg-rolling-update-handler.twin.sh/cordoned-at"
 	AnnotationRollingUpdateDrainedTimestamp    = "aws-eks-asg-rolling-update-handler.twin.sh/drained-at"
 	AnnotationRollingUpdateTerminatedTimestamp = "aws-eks-asg-rolling-update-handler.twin.sh/terminated-at"
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -135,7 +135,7 @@ func (k *Client) Drain(nodeName string, ignoreDaemonSets, deleteEmptyDirData boo
 	}
 	drainer := &drain.Helper{
 		Client:              k.client,
-		Force:               true,
+		Force:               true, // Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet
 		IgnoreAllDaemonSets: ignoreDaemonSets,
 		DeleteEmptyDirData:  deleteEmptyDirData,
 		GracePeriodSeconds:  podTerminationGracePeriod,

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -146,6 +146,13 @@ func (k *Client) Drain(nodeName string, ignoreDaemonSets, deleteEmptyDirData boo
 			log.Printf("[%s][DRAINER] evicted pod %s/%s", nodeName, pod.Namespace, pod.Name)
 		},
 	}
+	if !node.Spec.Unschedulable {
+		// Cordon the node if it's not already unschedulable
+		if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {
+			log.Printf("[%s][DRAINER] Failed to cordon node: %v", node.Name, err)
+			return err
+		}
+	}
 	if err := drain.RunNodeDrain(drainer, node.Name); err != nil {
 		log.Printf("[%s][DRAINER] Failed to drain node: %v", node.Name, err)
 		return err

--- a/main.go
+++ b/main.go
@@ -154,35 +154,23 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 		rand.Shuffle(len(outdatedInstances), func(i, j int) {
 			outdatedInstances[i], outdatedInstances[j] = outdatedInstances[j], outdatedInstances[i]
 		})
-		if config.Get().EagerCordoning {
-			for _, outdatedInstance := range outdatedInstances {
-				node, err := client.GetNodeByAutoScalingInstance(outdatedInstance)
-				if err != nil {
-					log.Printf("[%s][%s] Skipping because unable to get outdated node from Kubernetes: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
-					continue
-				}
-				_, minutesSinceCordoned, _, _ := getRollingUpdateTimestampsFromNode(node)
-				if minutesSinceCordoned == -1 {
-					log.Printf("[%s][%s] Cordoning node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-					if err := client.Cordon(node.Name); err != nil {
-						metrics.Server.Errors.Inc()
-						log.Printf("[%s][%s] Skipping because ran into error while cordoning node: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
-						continue
-					}
-					if err := k8s.AnnotateNodeByAutoScalingInstance(client, outdatedInstance, k8s.AnnotationRollingUpdateCordonedTimestamp, time.Now().Format(time.RFC3339)); err != nil {
-						log.Printf("[%s][%s] Skipping because unable to annotate node: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
-						continue
-					}
-				}
-			}
-		}
 		for _, outdatedInstance := range outdatedInstances {
 			node, err := client.GetNodeByAutoScalingInstance(outdatedInstance)
 			if err != nil {
 				log.Printf("[%s][%s] Skipping because unable to get outdated node from Kubernetes: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
 				continue
 			}
-			minutesSinceStarted, minutesSinceCordoned, minutesSinceDrained, minutesSinceTerminated := getRollingUpdateTimestampsFromNode(node)
+			if config.Get().EagerCordoning {
+				if !node.Spec.Unschedulable {
+					// If EagerCordoning is enabled and the node is schedulable, we need to cordon it.
+					if err := client.Cordon(node.Name); err != nil {
+						metrics.Server.Errors.Inc()
+						log.Printf("[%s][%s] Skipping because ran into error while cordoning node: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
+						continue
+					}
+				}
+			}
+			minutesSinceStarted, minutesSinceDrained, minutesSinceTerminated := getRollingUpdateTimestampsFromNode(node)
 			// Check if outdated nodes in k8s have been marked with annotation from aws-eks-asg-rolling-update-handler
 			if minutesSinceStarted == -1 {
 				log.Printf("[%s][%s] Starting node rollout process", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
@@ -198,20 +186,6 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 				hasEnoughResources := k8s.CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(client, node, updatedReadyNodes)
 				if hasEnoughResources {
 					log.Printf("[%s][%s] Updated nodes have enough resources available", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-					if minutesSinceCordoned == -1 {
-						log.Printf("[%s][%s] Cordoning node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-						err := client.Cordon(node.Name)
-						if err != nil {
-							metrics.Server.Errors.Inc()
-							log.Printf("[%s][%s] Skipping because ran into error while cordoning node: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
-							continue
-						} else {
-							// Only annotate if no error was encountered
-							_ = k8s.AnnotateNodeByAutoScalingInstance(client, outdatedInstance, k8s.AnnotationRollingUpdateCordonedTimestamp, time.Now().Format(time.RFC3339))
-						}
-					} else {
-						log.Printf("[%s][%s] Node has already been cordoned %d minutes ago, skipping", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), minutesSinceCordoned)
-					}
 					if minutesSinceDrained == -1 {
 						log.Printf("[%s][%s] Draining node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 						err := client.Drain(node.Name, config.Get().IgnoreDaemonSets, config.Get().DeleteEmptyDirData, config.Get().PodTerminationGracePeriod)
@@ -351,7 +325,7 @@ func getReadyNodesAndNumberOfNonReadyNodesOrInstances(client k8s.ClientAPI, upda
 	return updatedReadyNodes, numberOfNonReadyNodesOrInstances
 }
 
-func getRollingUpdateTimestampsFromNode(node *v1.Node) (minutesSinceStarted int, minutesSinceCordoned int, minutesSinceDrained int, minutesSinceTerminated int) {
+func getRollingUpdateTimestampsFromNode(node *v1.Node) (minutesSinceStarted, minutesSinceDrained, minutesSinceTerminated int) {
 	rollingUpdateStartedAt, ok := node.Annotations[k8s.AnnotationRollingUpdateStartedTimestamp]
 	if ok {
 		startedAt, err := time.Parse(time.RFC3339, rollingUpdateStartedAt)
@@ -360,15 +334,6 @@ func getRollingUpdateTimestampsFromNode(node *v1.Node) (minutesSinceStarted int,
 		}
 	} else {
 		minutesSinceStarted = -1
-	}
-	cordonedAtValue, ok := node.Annotations[k8s.AnnotationRollingUpdateCordonedTimestamp]
-	if ok {
-		cordonedAt, err := time.Parse(time.RFC3339, cordonedAtValue)
-		if err == nil {
-			minutesSinceCordoned = int(time.Since(cordonedAt).Minutes())
-		}
-	} else {
-		minutesSinceCordoned = -1
 	}
 	drainedAtValue, ok := node.Annotations[k8s.AnnotationRollingUpdateDrainedTimestamp]
 	if ok {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
According to #97, the `aws-eks-asg-rolling-update-handler.twin.sh/cordoned-at` annotation opens up the possibility of an upgrade never ending if a node is manually uncordoned after being annotated with the aforementioned annotation.

This removes the `aws-eks-asg-rolling-update-handler.twin.sh/cordoned-at` annotation, which was implemented in #42, and re-implements eager cordoning in a more stateless manner.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
