### PR TITLE
add label to exclude from external loadbalancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Therefore, this application will not run into any issues if it is restarted, res
 | METRICS                      | Expose metrics in Prometheus format at `:${METRICS_PORT}/metrics`                                                                                                                                                                                                             | no       | `""`        | 
 | SLOW_MODE                    | If enabled, every time a node is terminated during an execution, the current execution will stop rather than continuing to the next ASG                                                                                                                                       | no       | `false`     |
 | EAGER_CORDONING              | If enabled, all outdated nodes will get cordoned before any rolling update action. The default mode is to cordon a node just before draining it. See [#41](https://github.com/TwiN/aws-eks-asg-rolling-update-handler/issues/41) for possible consequences of enabling this.  | no       | `false`     |
+| EXCLUDE_FROM_EXTERNAL_LOAD_BALANCERS              | If enabled, node label `node.kubernetes.io/exclude-from-external-load-balancers=true` will be added to nodes before draining. See [#131](https://github.com/TwiN/aws-eks-asg-rolling-update-handler/pull/131) for more information  | no       | `false`     |
 
 **NOTE:** Only one of `CLUSTER_NAME`, `AUTODISCOVERY_TAGS` or `AUTO_SCALING_GROUP_NAMES` must be set.
 

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ type config struct {
 	MetricsPort                      int           // Defaults to 8080
 	SlowMode                         bool          // Defaults to false
 	EagerCordoning                   bool          // Defaults to false
-	ExcludeFromExternalLoadBalancers bool          // defaults to false
+	ExcludeFromExternalLoadBalancers bool          // Defaults to false
 }
 
 // Initialize is used to initialize the application's configuration
@@ -138,21 +138,22 @@ func Initialize() error {
 
 // Set sets the application's configuration and is intended to be used for testing purposes.
 // See Initialize() for production
-func Set(autoScalingGroupNames []string, ignoreDaemonSets, deleteEmptyDirData, eagerCordoning bool) {
+func Set(autoScalingGroupNames []string, ignoreDaemonSets, deleteEmptyDirData, eagerCordoning bool, excludeFromExternalLoadBalancers bool) {
 	cfg = &config{
-		AutoScalingGroupNames: autoScalingGroupNames,
-		IgnoreDaemonSets:      ignoreDaemonSets,
-		DeleteEmptyDirData:    deleteEmptyDirData,
-		EagerCordoning:        eagerCordoning,
-		ExecutionInterval:     time.Second * 20,
-		ExecutionTimeout:      time.Second * 900,
+		AutoScalingGroupNames:            autoScalingGroupNames,
+		IgnoreDaemonSets:                 ignoreDaemonSets,
+		DeleteEmptyDirData:               deleteEmptyDirData,
+		EagerCordoning:                   eagerCordoning,
+		ExcludeFromExternalLoadBalancers: excludeFromExternalLoadBalancers,
+		ExecutionInterval:                time.Second * 20,
+		ExecutionTimeout:                 time.Second * 900,
 	}
 }
 
 func Get() *config {
 	if cfg == nil {
 		log.Println("Config wasn't initialized prior to being called. Assuming this is a test.")
-		Set(nil, true, true, false)
+		Set(nil, true, true, false, false)
 	}
 	return cfg
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,48 +12,51 @@ import (
 var cfg *config
 
 const (
-	EnvEnvironment               = "ENVIRONMENT"
-	EnvDebug                     = "DEBUG"
-	EnvIgnoreDaemonSets          = "IGNORE_DAEMON_SETS"
-	EnvDeleteLocalData           = "DELETE_LOCAL_DATA" // Deprecated: in favor of DeleteEmptyDirData (DELETE_EMPTY_DIR_DATA)
-	EnvDeleteEmptyDirData        = "DELETE_EMPTY_DIR_DATA"
-	EnvClusterName               = "CLUSTER_NAME"
-	EnvAutodiscoveryTags         = "AUTODISCOVERY_TAGS"
-	EnvAutoScalingGroupNames     = "AUTO_SCALING_GROUP_NAMES"
-	EnvAwsRegion                 = "AWS_REGION"
-	EnvExecutionInterval         = "EXECUTION_INTERVAL"
-	EnvExecutionTimeout          = "EXECUTION_TIMEOUT"
-	EnvPodTerminationGracePeriod = "POD_TERMINATION_GRACE_PERIOD"
-	EnvMetrics                   = "METRICS"
-	EnvMetricsPort               = "METRICS_PORT"
-	EnvSlowMode                  = "SLOW_MODE"
-	EnvEagerCordoning            = "EAGER_CORDONING"
+	EnvEnvironment                      = "ENVIRONMENT"
+	EnvDebug                            = "DEBUG"
+	EnvIgnoreDaemonSets                 = "IGNORE_DAEMON_SETS"
+	EnvDeleteLocalData                  = "DELETE_LOCAL_DATA" // Deprecated: in favor of DeleteEmptyDirData (DELETE_EMPTY_DIR_DATA)
+	EnvDeleteEmptyDirData               = "DELETE_EMPTY_DIR_DATA"
+	EnvClusterName                      = "CLUSTER_NAME"
+	EnvAutodiscoveryTags                = "AUTODISCOVERY_TAGS"
+	EnvAutoScalingGroupNames            = "AUTO_SCALING_GROUP_NAMES"
+	EnvAwsRegion                        = "AWS_REGION"
+	EnvExecutionInterval                = "EXECUTION_INTERVAL"
+	EnvExecutionTimeout                 = "EXECUTION_TIMEOUT"
+	EnvPodTerminationGracePeriod        = "POD_TERMINATION_GRACE_PERIOD"
+	EnvMetrics                          = "METRICS"
+	EnvMetricsPort                      = "METRICS_PORT"
+	EnvSlowMode                         = "SLOW_MODE"
+	EnvEagerCordoning                   = "EAGER_CORDONING"
+	EnvExcludeFromExternalLoadBalancers = "EXLUDE_FROM_EXTERNAL_LOAD_BALANCERS"
 )
 
 type config struct {
-	Environment               string        // Optional
-	Debug                     bool          // Defaults to false
-	AutoScalingGroupNames     []string      // Required if AutodiscoveryTags not provided
-	AutodiscoveryTags         string        // Required if AutoScalingGroupNames not provided
-	AwsRegion                 string        // Defaults to us-west-2
-	IgnoreDaemonSets          bool          // Defaults to true
-	DeleteEmptyDirData        bool          // Defaults to true
-	ExecutionInterval         time.Duration // Defaults to 20s
-	ExecutionTimeout          time.Duration // Defaults to 900s
-	PodTerminationGracePeriod int           // Defaults to -1
-	Metrics                   bool          // Defaults to false
-	MetricsPort               int           // Defaults to 8080
-	SlowMode                  bool          // Defaults to false
-	EagerCordoning            bool          // Defaults to false
+	Environment                      string        // Optional
+	Debug                            bool          // Defaults to false
+	AutoScalingGroupNames            []string      // Required if AutodiscoveryTags not provided
+	AutodiscoveryTags                string        // Required if AutoScalingGroupNames not provided
+	AwsRegion                        string        // Defaults to us-west-2
+	IgnoreDaemonSets                 bool          // Defaults to true
+	DeleteEmptyDirData               bool          // Defaults to true
+	ExecutionInterval                time.Duration // Defaults to 20s
+	ExecutionTimeout                 time.Duration // Defaults to 900s
+	PodTerminationGracePeriod        int           // Defaults to -1
+	Metrics                          bool          // Defaults to false
+	MetricsPort                      int           // Defaults to 8080
+	SlowMode                         bool          // Defaults to false
+	EagerCordoning                   bool          // Defaults to false
+	ExcludeFromExternalLoadBalancers bool          // defaults to false
 }
 
 // Initialize is used to initialize the application's configuration
 func Initialize() error {
 	cfg = &config{
-		Environment:    strings.ToLower(os.Getenv(EnvEnvironment)),
-		Debug:          strings.ToLower(os.Getenv(EnvDebug)) == "true",
-		SlowMode:       strings.ToLower(os.Getenv(EnvSlowMode)) == "true",
-		EagerCordoning: strings.ToLower(os.Getenv(EnvEagerCordoning)) == "true",
+		Environment:                      strings.ToLower(os.Getenv(EnvEnvironment)),
+		Debug:                            strings.ToLower(os.Getenv(EnvDebug)) == "true",
+		SlowMode:                         strings.ToLower(os.Getenv(EnvSlowMode)) == "true",
+		EagerCordoning:                   strings.ToLower(os.Getenv(EnvEagerCordoning)) == "true",
+		ExcludeFromExternalLoadBalancers: strings.ToLower(os.Getenv(EnvExcludeFromExternalLoadBalancers)) == "true",
 	}
 	if clusterName := os.Getenv(EnvClusterName); len(clusterName) > 0 {
 		// See "Prerequisites" in https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ func TestInitialize_withMissingRequiredValues(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	Set([]string{"asg-a", "asg-b", "asg-c"}, true, true, false)
+	Set([]string{"asg-a", "asg-b", "asg-c"}, true, true, false, false)
 	config := Get()
 	if len(config.AutoScalingGroupNames) != 3 {
 		t.Error()

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/TwiN/gocache/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/drain"
@@ -19,6 +19,8 @@ const (
 	AnnotationRollingUpdateStartedTimestamp    = "aws-eks-asg-rolling-update-handler.twin.sh/started-at"
 	AnnotationRollingUpdateDrainedTimestamp    = "aws-eks-asg-rolling-update-handler.twin.sh/drained-at"
 	AnnotationRollingUpdateTerminatedTimestamp = "aws-eks-asg-rolling-update-handler.twin.sh/terminated-at"
+
+	LabelExcludeFromExternalLoadBalancers = "node.kubernetes.io/exclude-from-external-load-balancers"
 
 	nodesCacheKey = "nodes"
 )

--- a/k8s/util.go
+++ b/k8s/util.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes calculates the resources available in the target nodes
@@ -96,6 +96,24 @@ func AnnotateNodeByAutoScalingInstance(client ClientAPI, instance *autoscaling.I
 	if currentValue := annotations[key]; currentValue != value {
 		annotations[key] = value
 		node.SetAnnotations(annotations)
+		err = client.UpdateNode(node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Label Node adds an Label  to the Kubernetes node represented by a given AWS instance
+func LabelNodeByAutoScalingInstance(client ClientAPI, instance *autoscaling.Instance, key, value string) error {
+	node, err := client.GetNodeByAutoScalingInstance(instance)
+	if err != nil {
+		return err
+	}
+	labels := node.GetLabels()
+	if currentValue := labels[key]; currentValue != value {
+		labels[key] = value
+		node.SetLabels(labels)
 		err = client.UpdateNode(node)
 		if err != nil {
 			return err

--- a/k8stest/k8stest.go
+++ b/k8stest/k8stest.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -100,6 +100,7 @@ func CreateTestNode(name, availabilityZone, instanceId, allocatableCpu, allocata
 	}
 	node.SetName(name)
 	node.SetAnnotations(make(map[string]string))
+	node.SetLabels(make(map[string]string))
 	return node
 }
 

--- a/main.go
+++ b/main.go
@@ -187,6 +187,8 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 				if hasEnoughResources {
 					log.Printf("[%s][%s] Updated nodes have enough resources available", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 					if minutesSinceDrained == -1 {
+						log.Printf("[%s][%s] Label node to exlude from external load balancers", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
+						k8s.LabelNodeByAutoScalingInstance(client, outdatedInstance, "node.kubernetes.io/exclude-from-external-load-balancers", "twin")
 						log.Printf("[%s][%s] Draining node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 						err := client.Drain(node.Name, config.Get().IgnoreDaemonSets, config.Get().DeleteEmptyDirData, config.Get().PodTerminationGracePeriod)
 						if err != nil {

--- a/main.go
+++ b/main.go
@@ -187,8 +187,10 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 				if hasEnoughResources {
 					log.Printf("[%s][%s] Updated nodes have enough resources available", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 					if minutesSinceDrained == -1 {
-						log.Printf("[%s][%s] Label node to exlude from external load balancers", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-						k8s.LabelNodeByAutoScalingInstance(client, outdatedInstance, "node.kubernetes.io/exclude-from-external-load-balancers", "twin")
+						if config.Get().ExcludeFromExternalLoadBalancers {
+							log.Printf("[%s][%s] Label node to exlude from external load balancers", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
+							k8s.LabelNodeByAutoScalingInstance(client, outdatedInstance, "node.kubernetes.io/exclude-from-external-load-balancers", "true")
+						}
 						log.Printf("[%s][%s] Draining node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 						err := client.Drain(node.Name, config.Get().IgnoreDaemonSets, config.Get().DeleteEmptyDirData, config.Get().PodTerminationGracePeriod)
 						if err != nil {

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 					if minutesSinceDrained == -1 {
 						if config.Get().ExcludeFromExternalLoadBalancers {
 							log.Printf("[%s][%s] Label node to exlude from external load balancers", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-							k8s.LabelNodeByAutoScalingInstance(client, outdatedInstance, "node.kubernetes.io/exclude-from-external-load-balancers", "true")
+							k8s.LabelNodeByAutoScalingInstance(client, outdatedInstance, k8s.LabelExcludeFromExternalLoadBalancers, "true")
 						}
 						log.Printf("[%s][%s] Draining node", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 						err := client.Drain(node.Name, config.Get().IgnoreDaemonSets, config.Get().DeleteEmptyDirData, config.Get().PodTerminationGracePeriod)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Not yet i can open one if needed. Problem is that if i have a NodePort to expose for example my nginx ingress controller to an Elastic Loadbalancer. The Loadbalancer is not notified if i terminate one of our Nodes. Therefore, Kubernetes invented the exclude-for-external-loadbalancers label. When i add this label to a node the aws-loadbalancer-controller starts deregistering the Node from their TargetGroup which prevents Connections issue during Rolling Update.

For Reference: https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers

Implementation in Karpenter: https://github.com/aws/karpenter/pull/2518



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
