### PR TITLE
fix: Always use the updated ASG definition when incrementing its desired capacity

### DIFF
--- a/k8s/util.go
+++ b/k8s/util.go
@@ -7,16 +7,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes calculates the resources available in the target nodes
+// CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode calculates the resources available in the target nodes
 // and compares them with the resources that would be required if the old node were to be drained
 //
-// This is not fool proof: 2 targetNodes with 1G available in each would cause the assumption that you can fit
+// This is not foolproof: 2 targetNodes with 1G available in each would cause the assumption that you can fit
 // a 2G pod in the targetNodes when you obviously can't (you'd need 1 node with 2G available, not 2 with 1G)
 // That's alright, because the purpose is to provide a smooth rolling upgrade, not a flawless experience,  and
 // while the latter is definitely possible, it would slow down the process by quite a bit. In a way, this is
 // the beauty of co-existing with the cluster autoscaler; an extra node will be spun up to handle the leftovers,
 // if any.
-func CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(client ClientAPI, oldNode *v1.Node, targetNodes []*v1.Node) bool {
+func CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(client ClientAPI, oldNode *v1.Node, targetNodes []*v1.Node) bool {
 	totalAvailableTargetCPU := int64(0)
 	totalAvailableTargetMemory := int64(0)
 	// Get resources available in target nodes
@@ -104,7 +104,7 @@ func AnnotateNodeByAutoScalingInstance(client ClientAPI, instance *autoscaling.I
 	return nil
 }
 
-// Label Node adds an Label  to the Kubernetes node represented by a given AWS instance
+// LabelNodeByAutoScalingInstance adds a Label to the Kubernetes node represented by a given AWS instance
 func LabelNodeByAutoScalingInstance(client ClientAPI, instance *autoscaling.Instance, key, value string) error {
 	node, err := client.GetNodeByAutoScalingInstance(instance)
 	if err != nil {

--- a/k8s/util_test.go
+++ b/k8s/util_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(t *testing.T) {
 	// allocatable cpu & memory aren't used for the old node.
 	// They're only used by the target nodes (newNode, in this case) to calculate if the leftover resources from moving
 	// the pods from the old node to the new node are positive (if the leftover is negative, it means there's not enough
@@ -17,7 +17,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(t *testing.T) {
 	oldNodePod := k8stest.CreateTestPod("old-pod-1", oldNode.Name, "100m", "100Mi", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode, newNode}, []v1.Pod{oldNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{&newNode})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{&newNode})
 	if !hasEnoughResources {
 		t.Error("should've had enough space in node")
 	}
@@ -26,14 +26,14 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(t *testing.T) {
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_whenNotEnoughSpaceInNewNodes(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_whenNotEnoughSpaceInNewNodes(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2a", "i-034fa1dfbfd35f8bb", "0m", "0m")
 	newNode := k8stest.CreateTestNode("new-node-1", "us-west-2c", "i-0b22d79604221412c", "1000m", "1000Mi")
 	oldNodePod := k8stest.CreateTestPod("old-pod-1", oldNode.Name, "200m", "200Mi", false, v1.PodRunning)
 	newNodePod := k8stest.CreateTestPod("new-pod-1", newNode.Name, "900m", "200Mi", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode, newNode}, []v1.Pod{oldNodePod, newNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{&newNode})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{&newNode})
 	if hasEnoughResources {
 		t.Error("shouldn't have had enough space in node")
 	}
@@ -42,7 +42,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_whenNotEnoughSpac
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultiplePods(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_withMultiplePods(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2c", "i-0b22d79604221412c", "0m", "0m")
 	newNode := k8stest.CreateTestNode("new-node-1", "us-west-2b", "i-07550830aef9e4179", "1000m", "1000Mi")
 	oldNodeFirstPod := k8stest.CreateTestPod("old-pod-1", oldNode.Name, "300m", "0", false, v1.PodRunning)
@@ -51,7 +51,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultiplePods(
 	newNodePod := k8stest.CreateTestPod("new-pod-1", newNode.Name, "200m", "200Mi", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode, newNode}, []v1.Pod{oldNodeFirstPod, oldNodeSecondPod, oldNodeThirdPod, newNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{&newNode})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{&newNode})
 	if hasEnoughResources {
 		t.Error("shouldn't have had enough space in node")
 	}
@@ -60,7 +60,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultiplePods(
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultipleTargetNodes(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_withMultipleTargetNodes(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2b", "i-07550830aef9e4179", "0m", "0m")
 	firstNewNode := k8stest.CreateTestNode("new-node-1", "us-west-2a", "i-034fa1dfbfd35f8bb", "1000m", "1000Mi")
 	secondNewNode := k8stest.CreateTestNode("new-node-2", "us-west-2b", "i-0918aff89347cef0c", "1000m", "1000Mi")
@@ -69,7 +69,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultipleTarge
 	oldNodeThirdPod := k8stest.CreateTestPod("old-node-pod-3", oldNode.Name, "500m", "0", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode, firstNewNode, secondNewNode}, []v1.Pod{oldNodeFirstPod, oldNodeSecondPod, oldNodeThirdPod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{&firstNewNode, &secondNewNode})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{&firstNewNode, &secondNewNode})
 	if !hasEnoughResources {
 		t.Error("should've had enough space in node")
 	}
@@ -78,7 +78,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withMultipleTarge
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withPodsSpreadAcrossMultipleTargetNodes(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_withPodsSpreadAcrossMultipleTargetNodes(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2a", "i-034fa1dfbfd35f8bb", "0m", "0m")
 	firstNewNode := k8stest.CreateTestNode("new-node-1", "us-west-2a", "i-07550830aef9e4179", "1000m", "1000Mi")
 	secondNewNode := k8stest.CreateTestNode("new-node-2", "us-west-2a", "i-0147ad0816c210dae", "1000m", "1000Mi")
@@ -89,7 +89,7 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withPodsSpreadAcr
 	oldNodeThirdPod := k8stest.CreateTestPod("old-node-pod-3", oldNode.Name, "0", "500Mi", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode, firstNewNode, secondNewNode}, []v1.Pod{oldNodeFirstPod, oldNodeSecondPod, oldNodeThirdPod, firstNewNodePod, secondNewNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{&firstNewNode, &secondNewNode})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{&firstNewNode, &secondNewNode})
 	if hasEnoughResources {
 		t.Error("shouldn't have had enough space in node")
 	}
@@ -98,23 +98,23 @@ func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withPodsSpreadAcr
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withNoTargetNodes(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_withNoTargetNodes(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2a", "i-034fa1dfbfd35f8bb", "0m", "0m")
 	oldNodePod := k8stest.CreateTestPod("old-node-pod-1", oldNode.Name, "500Mi", "500Mi", false, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode}, []v1.Pod{oldNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{})
 	if hasEnoughResources {
 		t.Error("there's no target nodes; there definitely shouldn't have been enough space")
 	}
 }
 
-func TestCheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes_withNoTargetNodesButOldNodeOnlyHasPodsFromDaemonSets(t *testing.T) {
+func TestCheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode_withNoTargetNodesButOldNodeOnlyHasPodsFromDaemonSets(t *testing.T) {
 	oldNode := k8stest.CreateTestNode("old-node", "us-west-2a", "i-034fa1dfbfd35f8bb", "0m", "0m")
 	oldNodePod := k8stest.CreateTestPod("old-node-pod-1", oldNode.Name, "500Mi", "500Mi", true, v1.PodRunning)
 	mockClient := k8stest.NewMockClient([]v1.Node{oldNode}, []v1.Pod{oldNodePod})
 
-	hasEnoughResources := CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(mockClient, &oldNode, []*v1.Node{})
+	hasEnoughResources := CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(mockClient, &oldNode, []*v1.Node{})
 	if !hasEnoughResources {
 		t.Error("there's no target nodes, but the only pods in the old node are from daemon sets")
 	}

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 			} else {
 				log.Printf("[%s][%s] Node already started rollout process", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 				// check if existing updatedInstances have the capacity to support what's inside this node
-				hasEnoughResources := k8s.CheckIfNodeHasEnoughResourcesToTransferAllPodsInNodes(client, node, updatedReadyNodes)
+				hasEnoughResources := k8s.CheckIfUpdatedNodesHaveEnoughResourcesToScheduleAllPodsFromOldNode(client, node, updatedReadyNodes)
 				if hasEnoughResources {
 					log.Printf("[%s][%s] Updated nodes have enough resources available", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
 					if minutesSinceDrained == -1 {
@@ -242,7 +242,7 @@ func DoHandleRollingUpgrade(client k8s.ClientAPI, ec2Service ec2iface.EC2API, au
 						continue
 					}
 					log.Printf("[%s][%s] Updated nodes do not have enough resources available, increasing desired count by 1", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))
-					err := cloud.SetAutoScalingGroupDesiredCount(autoScalingService, autoScalingGroup, aws.Int64Value(autoScalingGroup.DesiredCapacity)+1)
+					err := cloud.IncrementAutoScalingGroupDesiredCount(autoScalingService, aws.StringValue(autoScalingGroup.AutoScalingGroupName))
 					if err != nil {
 						log.Printf("[%s][%s] Unable to increase ASG desired size: %v", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId), err.Error())
 						log.Printf("[%s][%s] Skipping", aws.StringValue(autoScalingGroup.AutoScalingGroupName), aws.StringValue(outdatedInstance.InstanceId))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
As per #129, if the duration between when the ASGs are initially retrieved and when the ASG's desired capacity is modified, it's possible for aws-eks-asg-rolling-update-handler to undo previous scaling activities made by other applications such as cluster-autoscaler. 

This change makes it so the updated ASG definition is retrieved immediately before the increment takes place.

Fixes #129


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
